### PR TITLE
Fix inference with cpu only configs

### DIFF
--- a/monailabel/monaivista/lib/infers/vista_point_2pt5.py
+++ b/monailabel/monaivista/lib/infers/vista_point_2pt5.py
@@ -64,7 +64,7 @@ class VISTAPOINT2PT5(BasicInferTask):
         ]
 
     def inferer(self, data=None) -> Inferer:
-        return VISTASliceInferer()
+        return VISTASliceInferer(device=data.get("device") if data else None)
 
     def inverse_transforms(self, data=None):
         return []

--- a/monailabel/monaivista/lib/model/vista_point_2pt5/utils/utils.py
+++ b/monailabel/monaivista/lib/model/vista_point_2pt5/utils/utils.py
@@ -80,14 +80,16 @@ def distributed_all_gather(
     return tensor_list_out
 
 
-def prepare_sam_val_input(inputs, class_prompts, point_prompts, start_idx, original_affine=None):
+def prepare_sam_val_input(inputs, class_prompts, point_prompts, start_idx, original_affine=None, device=None):
     # Don't exclude background in val but will ignore it in metric calculation
     H, W = inputs.shape[1:]
     foreground_all = point_prompts["foreground"]
     background_all = point_prompts["background"]
 
     class_list = [[i + 1] for i in class_prompts]
-    unique_labels = torch.tensor(class_list).long().cuda()
+    unique_labels = torch.tensor(class_list).long()
+    if device == "cuda" or (isinstance(device, torch.device) and device.type == "cuda"):
+        unique_labels = unique_labels.cuda()
 
     volume_point_coords = [cp for cp in foreground_all]
     volume_point_labels = [1] * len(foreground_all)
@@ -129,8 +131,11 @@ def prepare_sam_val_input(inputs, class_prompts, point_prompts, start_idx, origi
         prepared_input[0].update({"labels": unique_labels})
 
     if point_coords:
-        point_coords = torch.tensor(point_coords).long().cuda()
-        point_labels = torch.tensor(point_labels).long().cuda()
+        point_coords = torch.tensor(point_coords).long()
+        point_labels = torch.tensor(point_labels).long()
+        if device == "cuda" or (isinstance(device, torch.device) and device.type == "cuda"):
+            point_coords = point_coords.cuda()
+            point_labels = point_labels.cuda()
 
         prepared_input[0].update({"point_coords": point_coords, "point_labels": point_labels})
 


### PR DESCRIPTION
### Description

Exciting work here! I noticed inference has some hard coded `.cuda()` calls. The "everything" segmentation isn't really feasible on CPU, and there seem to be some issues with multiple-prompt infers on my end, but this at least allows trying out single prompt infers with CPU only configs.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
